### PR TITLE
docs: fix broken absolute paths in README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ This performs GitHub SSH key lookup for identity pinning (TOFU) and stores a pin
 
 ## Auto-generated CLI options
 See the generated options table and raw `--help` output:
-- [CLI_HELP.md](/Users/kuma/Develop/opensource/ende/CLI_HELP.md)
+- [CLI_HELP.md](CLI_HELP.md)
 
 ## Open Source
-- License: [LICENSE](/Users/kuma/Develop/opensource/ende/LICENSE)
-- Contributing guide: [CONTRIBUTING.md](/Users/kuma/Develop/opensource/ende/CONTRIBUTING.md)
-- Code of Conduct: [CODE_OF_CONDUCT.md](/Users/kuma/Develop/opensource/ende/CODE_OF_CONDUCT.md)
-- Security policy: [SECURITY.md](/Users/kuma/Develop/opensource/ende/SECURITY.md)
-- Changelog: [CHANGELOG.md](/Users/kuma/Develop/opensource/ende/CHANGELOG.md)
+- License: [LICENSE](LICENSE)
+- Contributing guide: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Code of Conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- Security policy: [SECURITY.md](SECURITY.md)
+- Changelog: [CHANGELOG.md](CHANGELOG.md)


### PR DESCRIPTION
## Summary
- README.md의 링크가 절대 경로(`/Users/kuma/...`)로 되어 있어 다른 사용자 환경에서 동작하지 않는 문제 수정
- 6개 링크를 상대 경로로 변환: `CLI_HELP.md`, `LICENSE`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CHANGELOG.md`

## Test plan
- [x] GitHub에서 README.md 렌더링 시 모든 링크가 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)