### PR TITLE
docs: add installation guides for brew tap and release binaries

### DIFF
--- a/CLI_HELP.md
+++ b/CLI_HELP.md
@@ -10,6 +10,7 @@ Auto-generated from command --help outputs on 2026-03-05.
 |---|---|
 | `--debug` | enable diagnostic logs to stderr |
 | `-h, --help` | help for ende |
+| `-V, --version` | print version information |
 
 ### ende key
 
@@ -60,6 +61,14 @@ Auto-generated from command --help outputs on 2026-03-05.
 | Flag | Description |
 |---|---|
 | `-h, --help` | help for use |
+| `--name string` | key id |
+| `--debug` | enable diagnostic logs to stderr |
+
+### ende key share
+
+| Flag | Description |
+|---|---|
+| `-h, --help` | help for share |
 | `--name string` | key id |
 | `--debug` | enable diagnostic logs to stderr |
 
@@ -150,11 +159,20 @@ Auto-generated from command --help outputs on 2026-03-05.
 | `--signing-public string` | Ed25519 signing public key (base64) |
 | `--debug` | enable diagnostic logs to stderr |
 
+### ende unregister
+
+| Flag | Description |
+|---|---|
+| `--force` | ignore if alias is not registered |
+| `-h, --help` | help for unregister |
+| `--debug` | enable diagnostic logs to stderr |
+
 ### ende encrypt
 
 | Flag | Description |
 |---|---|
 | `--binary` | output raw binary envelope |
+| `-f, --file string` | input file path (alias of --in) |
 | `-h, --help` | help for encrypt |
 | `-i, --in string` | input path or - (default "-") |
 | `-o, --out string` | output path or - (default "-") |
@@ -202,11 +220,14 @@ Available Commands:
   recipient   Manage recipient aliases
   register    Register recipient and trusted sender in one step
   sender      Manage trusted sender signing keys
+  unregister  Remove recipient and trusted sender registration for an alias
   verify      Verify signature without decrypting
+  version     Print version information
 
 Flags:
-      --debug   enable diagnostic logs to stderr
-  -h, --help    help for ende
+      --debug     enable diagnostic logs to stderr
+  -h, --help      help for ende
+  -V, --version   print version information
 
 Use "ende [command] --help" for more information about a command.
 ```
@@ -227,6 +248,7 @@ Available Commands:
   import      Import age recipient public key into recipient aliases
   keygen      Generate X25519 recipient and Ed25519 signing key pair
   list        List local keys and recipients
+  share       Print share token for an existing local key
   use         Set default signer key ID for encrypt
 
 Flags:
@@ -323,6 +345,22 @@ Usage:
 
 Flags:
   -h, --help          help for use
+      --name string   key id
+
+Global Flags:
+      --debug   enable diagnostic logs to stderr
+```
+
+### ende key share --help
+
+```text
+Print share token for an existing local key
+
+Usage:
+  ende key share [flags]
+
+Flags:
+  -h, --help          help for share
       --name string   key id
 
 Global Flags:
@@ -523,6 +561,25 @@ Global Flags:
       --debug   enable diagnostic logs to stderr
 ```
 
+### ende unregister --help
+
+```text
+Remove recipient and trusted sender registration for an alias
+
+Usage:
+  ende unregister <alias> [flags]
+
+Aliases:
+  unregister, unreg
+
+Flags:
+      --force   ignore if alias is not registered
+  -h, --help    help for unregister
+
+Global Flags:
+      --debug   enable diagnostic logs to stderr
+```
+
 ### ende encrypt --help
 
 ```text
@@ -536,6 +593,7 @@ Aliases:
 
 Flags:
       --binary           output raw binary envelope
+  -f, --file string      input file path (alias of --in)
   -h, --help             help for encrypt
   -i, --in string        input path or - (default "-")
   -o, --out string       output path or - (default "-")

--- a/README.md
+++ b/README.md
@@ -17,6 +17,42 @@
 go build ./cmd/ende
 ```
 
+## Install with Homebrew (tap)
+```bash
+brew tap DevopsArtFactory/ende https://github.com/DevopsArtFactory/homebrew-ende
+brew install ende
+```
+
+Upgrade:
+```bash
+brew update
+brew upgrade ende
+```
+
+Verify:
+```bash
+ende --version
+```
+
+## Install from GitHub Release (Linux / Windows)
+Replace `vX.Y.Z` with the release tag.
+
+Linux (amd64):
+```bash
+VERSION=vX.Y.Z
+curl -fL "https://github.com/DevopsArtFactory/ende/releases/download/${VERSION}/ende-linux-amd64" -o ende
+chmod +x ende
+sudo mv ende /usr/local/bin/ende
+ende --version
+```
+
+Windows (amd64, PowerShell):
+```powershell
+$Version = "vX.Y.Z"
+Invoke-WebRequest -Uri "https://github.com/DevopsArtFactory/ende/releases/download/$Version/ende-windows-amd64.exe" -OutFile "ende.exe"
+.\ende.exe --version
+```
+
 ## Docker build
 Build with containerized Go toolchain (host env independent):
 ```bash

--- a/USAGE_EN.md
+++ b/USAGE_EN.md
@@ -9,6 +9,32 @@ Core guarantees:
 - Local keyring is the trust root (GitHub username mode is optional)
 - Decrypt requires a **trusted sender pin** (`sender_key_id` + signing public key match)
 
+## Install (Homebrew tap)
+```bash
+brew tap DevopsArtFactory/ende https://github.com/DevopsArtFactory/homebrew-ende
+brew install ende
+ende --version
+```
+
+## Install from GitHub Release (Linux / Windows)
+Replace `vX.Y.Z` with the release tag.
+
+Linux (amd64):
+```bash
+VERSION=vX.Y.Z
+curl -fL "https://github.com/DevopsArtFactory/ende/releases/download/${VERSION}/ende-linux-amd64" -o ende
+chmod +x ende
+sudo mv ende /usr/local/bin/ende
+ende --version
+```
+
+Windows (amd64, PowerShell):
+```powershell
+$Version = "vX.Y.Z"
+Invoke-WebRequest -Uri "https://github.com/DevopsArtFactory/ende/releases/download/$Version/ende-windows-amd64.exe" -OutFile "ende.exe"
+.\ende.exe --version
+```
+
 ---
 
 ## 2. Initial Setup (One-time per user)

--- a/USAGE_KO.md
+++ b/USAGE_KO.md
@@ -9,6 +9,32 @@
 - 로컬 keyring을 신뢰 루트로 사용 (GitHub username은 선택 기능)
 - 복호화 시 **신뢰된 송신자 pin**(`sender_key_id` + 서명 공개키 일치) 필수
 
+## 설치 (Homebrew tap)
+```bash
+brew tap DevopsArtFactory/ende https://github.com/DevopsArtFactory/homebrew-ende
+brew install ende
+ende --version
+```
+
+## GitHub Release 바이너리 설치 (Linux / Windows)
+`vX.Y.Z`를 실제 태그로 바꿔서 사용하세요.
+
+Linux (amd64):
+```bash
+VERSION=vX.Y.Z
+curl -fL "https://github.com/DevopsArtFactory/ende/releases/download/${VERSION}/ende-linux-amd64" -o ende
+chmod +x ende
+sudo mv ende /usr/local/bin/ende
+ende --version
+```
+
+Windows (amd64, PowerShell):
+```powershell
+$Version = "vX.Y.Z"
+Invoke-WebRequest -Uri "https://github.com/DevopsArtFactory/ende/releases/download/$Version/ende-windows-amd64.exe" -OutFile "ende.exe"
+.\ende.exe --version
+```
+
 ---
 
 ## 2. 초기 준비 (각자 1회)


### PR DESCRIPTION
## Summary
- add Homebrew tap installation steps
- add Linux/Windows install steps from GitHub Release tag binaries
- update CLI help snapshot and usage docs
 
## Files
- README.md
- USAGE_EN.md
- USAGE_KO.md
- CLI_HELP.md