### PR TITLE
feat: add interactive paste prompt for decrypt command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 dist/*
-ende
+/ende
 
 .DS_*

--- a/cmd/ende/crypto_cmd.go
+++ b/cmd/ende/crypto_cmd.go
@@ -141,7 +141,16 @@ func newDecryptCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			envelopeBytes, err := endeio.ReadInput(in)
+			var envelopeBytes []byte
+			if in == "-" {
+				if stat, _ := os.Stdin.Stat(); stat.Mode()&os.ModeCharDevice != 0 {
+					envelopeBytes, err = readEnvelopeInteractive(cmd.InOrStdin(), cmd.ErrOrStderr())
+				} else {
+					envelopeBytes, err = endeio.ReadInput(in)
+				}
+			} else {
+				envelopeBytes, err = endeio.ReadInput(in)
+			}
 			if err != nil {
 				return err
 			}

--- a/cmd/ende/prompt.go
+++ b/cmd/ende/prompt.go
@@ -56,6 +56,28 @@ func promptRegisterInput(in io.Reader, errw io.Writer) (alias string, recipientO
 	return strings.TrimSpace(alias), trimmed, strings.TrimSpace(signingPublic), nil
 }
 
+func readEnvelopeInteractive(in io.Reader, errw io.Writer) ([]byte, error) {
+	fmt.Fprintln(errw, "Paste encrypted envelope, then press Enter:")
+	var buf strings.Builder
+	scanner := bufio.NewScanner(in)
+	for scanner.Scan() {
+		line := scanner.Text()
+		buf.WriteString(line)
+		buf.WriteString("\n")
+		if strings.TrimSpace(line) == "-----END ENDE ENVELOPE-----" {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read envelope: %w", err)
+	}
+	result := buf.String()
+	if result == "" {
+		return nil, fmt.Errorf("read envelope: empty input")
+	}
+	return []byte(result), nil
+}
+
 func promptShareRegisterInput(in io.Reader, errw io.Writer) (share string, aliasOverride string, err error) {
 	r := bufio.NewReader(in)
 	fmt.Fprint(errw, "share token (ENDE-PUB-1:...): ")

--- a/cmd/ende/prompt_test.go
+++ b/cmd/ende/prompt_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestReadEnvelopeInteractive(t *testing.T) {
+	envelope := strings.Join([]string{
+		"-----BEGIN ENDE ENVELOPE-----",
+		"dGVzdGRhdGE=",
+		"-----END ENDE ENVELOPE-----",
+	}, "\n") + "\n"
+
+	in := strings.NewReader(envelope)
+	var errBuf bytes.Buffer
+
+	got, err := readEnvelopeInteractive(in, &errBuf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if string(got) != envelope {
+		t.Errorf("got %q, want %q", string(got), envelope)
+	}
+
+	if !strings.Contains(errBuf.String(), "Paste encrypted envelope") {
+		t.Error("expected prompt message on stderr")
+	}
+}
+
+func TestReadEnvelopeInteractive_StopsAtEndMarker(t *testing.T) {
+	input := strings.Join([]string{
+		"-----BEGIN ENDE ENVELOPE-----",
+		"dGVzdGRhdGE=",
+		"-----END ENDE ENVELOPE-----",
+		"this line should not be included",
+	}, "\n") + "\n"
+
+	in := strings.NewReader(input)
+	var errBuf bytes.Buffer
+
+	got, err := readEnvelopeInteractive(in, &errBuf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(string(got), "this line should not be included") {
+		t.Error("reader should stop at END marker")
+	}
+}
+
+func TestReadEnvelopeInteractive_EmptyInput(t *testing.T) {
+	in := strings.NewReader("")
+	var errBuf bytes.Buffer
+
+	_, err := readEnvelopeInteractive(in, &errBuf)
+	if err == nil {
+		t.Fatal("expected error for empty input")
+	}
+}


### PR DESCRIPTION
## Summary
- When running `ende decrypt` without `--in` and stdin is a terminal, show a prompt: `Paste encrypted envelope, then press Enter:`
- Auto-detect end of input when `-----END ENDE ENVELOPE-----` is encountered — no Ctrl+D needed
- Fix `.gitignore` rule (`ende` → `/ende`) that was unintentionally ignoring `cmd/ende/` directory

## Related Issues
Closes #7

## Validation
- Added 3 unit tests for `readEnvelopeInteractive` (normal input, stop-at-marker, empty input)
- All existing tests pass (`go test ./...`)
- Build succeeds (`go build ./...`)