### PR TITLE
docs: reprioritize operator safety roadmap

### DIFF
--- a/.kiro/feature-recommendations.md
+++ b/.kiro/feature-recommendations.md
@@ -7,6 +7,11 @@
 - CLI refactored from monolithic main.go into focused command files
 - Test coverage significantly improved across all internal packages
 
+## Current Reassessment
+- The next milestone should prioritize reducing operator mistakes, not just adding platform breadth.
+- The highest-leverage improvements are the ones that increase confidence at the moment of encrypt/decrypt.
+- Near-term roadmap should focus on: masked secret entry, preflight diagnostics, recipient confirmation, and safer plaintext output handling.
+
 ## 1. Core Security Features
 
 ### 1.1 Key Rotation - MEDIUM PRIORITY (downgraded from HIGH)
@@ -85,7 +90,73 @@ ende decrypt -i secret.ende
 
 ## 2. Usability Improvements
 
-### 2.1 Interactive Setup Wizard - MEDIUM PRIORITY
+### 2.1 Safety Doctor / Preflight Checks - HIGH PRIORITY
+**Why now**: Users need a quick way to confirm their local environment is safe before exchanging secrets.
+
+**Implementation Proposal**:
+```bash
+ende doctor
+# → Validate:
+# 1. keyring path and permissions
+# 2. private key file permissions
+# 3. default signer configuration
+# 4. recipient/sender registration consistency
+# 5. stale or risky trust entries
+```
+
+**Suggested Checks**:
+- Missing default signer
+- Missing trusted sender for a registered recipient
+- Broken private key paths
+- Keyring file mode warnings
+- GitHub pin mismatch or unverified GitHub-mode onboarding reminders
+
+---
+
+### 2.2 Safe Secret Prompt UX - HIGH PRIORITY
+**Current**: `encrypt --prompt` is convenient, but it should behave like a secret input flow instead of a plain terminal read.
+
+**Implementation Proposal**:
+```bash
+ende encrypt -t bob --prompt -o secret.txt
+# → masked input
+# → optional confirm input
+# → empty input rejected
+# → weak-value warning before encryption
+```
+
+**Design Goals**:
+- Never echo secret input back to terminal
+- Reduce accidental whitespace/newline mistakes
+- Warn on obviously weak secrets without blocking all usage
+- Keep non-interactive stdin/file workflows unchanged
+
+---
+
+### 2.3 Recipient Confirmation and Send Summary - HIGH PRIORITY
+**Why now**: The most likely user mistake is encrypting to the wrong alias or overlooking who will be able to decrypt.
+
+**Implementation Proposal**:
+```bash
+ende encrypt -t bob -t diana --confirm
+# → recipient summary:
+#    - bob (fp=abcd1234)
+#    - diana (fp=efgh5678)
+#    signer: alice
+#    output: secret.txt
+#    format: armored text
+# Continue? [y/N]
+```
+
+**Suggested Behavior**:
+- Default to confirmation on first-send or multi-recipient flows
+- Show short fingerprints and source metadata
+- Allow `--yes` for automation
+- Reuse the same summary in tutorial/onboarding flows
+
+---
+
+### 2.4 Interactive Setup Wizard - MEDIUM PRIORITY
 **Current**: Many command options create high barrier for beginners
 
 **Implementation Proposal**:
@@ -100,7 +171,7 @@ ende init
 
 ---
 
-### 2.2 GUI Tool - LOW PRIORITY
+### 2.5 GUI Tool - LOW PRIORITY
 **Need**: Support users unfamiliar with CLI
 
 **Implementation Options**:
@@ -121,7 +192,7 @@ ende init
 
 ---
 
-### 2.3 IDE Plugins - MEDIUM PRIORITY
+### 2.6 IDE Plugins - MEDIUM PRIORITY
 **Goal**: Integrate into development workflow
 
 **VS Code Extension**:
@@ -141,7 +212,27 @@ DATABASE_URL=postgres://... // Right-click → "Encrypt with Ende"
 
 ---
 
-### 2.4 Shell Autocompletion - LOW PRIORITY
+### 2.7 Safer Plaintext Output Modes - MEDIUM PRIORITY
+**Why now**: stdout protection already exists, but file-based plaintext output can still be made safer for day-to-day use.
+
+**Implementation Proposal**:
+```bash
+ende decrypt -i secret.ende --out-temp
+# → writes plaintext to a temporary 0600 file
+# → prints path for short-term use
+
+ende decrypt -i secret.ende -o secrets.txt --no-clobber
+# → refuses overwrite unless explicitly allowed
+```
+
+**Additional Options**:
+- Force plaintext output files to `0600`
+- `--no-clobber` for safe default writes
+- ephemeral display mode for one-time viewing
+
+---
+
+### 2.8 Shell Autocompletion - LOW PRIORITY
 ```bash
 # Bash/Zsh/Fish autocompletion
 ende completion bash > /etc/bash_completion.d/ende
@@ -521,6 +612,9 @@ ende tutorial start
 - Team onboarding procedures
 - Incident response playbook
 - Compliance checklists
+- Recipient fingerprint verification checklist
+- Recommended `ende doctor` checks before first production use
+- Plaintext handling guidance for local development machines
 
 ---
 
@@ -540,28 +634,28 @@ ende migrate to-sops --input secrets.ende
 ## 9. Implementation Priority by Phase
 
 ### Phase 1: Core Security (1-2 months)
-1. ✅ Complete key rotation implementation
-2. ✅ Key backup/recovery
-3. ✅ Audit logging
-4. ✅ Key revocation mechanism
+1. Safe secret prompt UX
+2. `ende doctor` preflight command
+3. Recipient confirmation / first-send summary
+4. Safer plaintext file output modes
 
 ### Phase 2: Team Collaboration (2-3 months)
-1. ✅ Team keyring sharing
-2. ✅ CI/CD integration
-3. ✅ Secret bundles
-4. ✅ Interactive setup wizard
+1. Key backup/recovery
+2. Team keyring sharing
+3. CI/CD integration
+4. Interactive setup wizard
 
 ### Phase 3: Advanced Features (3-6 months)
-1. ✅ IDE plugins
-2. ✅ Kubernetes integration
-3. ✅ MFA support
-4. ✅ Policy-based access control
+1. Secret bundles
+2. IDE plugins
+3. Kubernetes integration
+4. MFA support
 
 ### Phase 4: Expansion and Optimization (6+ months)
-1. ✅ GUI tools
-2. ✅ HSM support
-3. ✅ Large file handling
-4. ✅ Advanced monitoring
+1. Policy-based access control
+2. GUI tools
+3. HSM support
+4. Advanced monitoring
 
 ---
 
@@ -587,11 +681,11 @@ ende migrate to-sops --input secrets.ende
 
 ## Conclusion
 
-Ende is built on a solid foundation, and adding these features incrementally 
-can grow it into an enterprise-grade secret management tool.
+Ende is built on a solid foundation, and the next step should optimize for
+safe everyday usage before expanding into broader platform features.
 
 Priorities:
-1. **Security Enhancement** (key rotation, backup, revocation)
-2. **Team Collaboration** (shared keyring, CI/CD)
-3. **Usability** (GUI, IDE plugins)
-4. **Scalability** (plugins, integrations)
+1. **Operator Safety** (masked prompts, recipient confirmation, safer plaintext handling)
+2. **Security Assurance** (`ende doctor`, trust checks, backup/recovery)
+3. **Team Collaboration** (shared keyring, CI/CD)
+4. **Expansion** (GUI, IDE plugins, integrations)

--- a/.kiro/implementation-priorities.md
+++ b/.kiro/implementation-priorities.md
@@ -31,132 +31,77 @@
 
 ## Quick Wins (1-2 weeks)
 
-### 1. Auto-fix Key File Permissions
-**Current**: Only validates permissions, fails on error
-**Improvement**: Automatically set 0600 permissions
+### 1. Mask Interactive Secret Input
+**Current**: `encrypt --prompt` reads terminal input as plain text.
+**Improvement**: Switch to TTY-aware masked input while keeping stdin/file flows unchanged.
 
 ```go
-// internal/policy/policy.go
-func EnsurePrivateFile(path string) error {
-    info, err := os.Stat(path)
-    if err != nil {
-        return fmt.Errorf("stat private file %s: %w", path, err)
-    }
-    mode := info.Mode().Perm()
-    if mode != 0o600 {
-        // Auto-fix
-        if err := os.Chmod(path, 0o600); err != nil {
-            return fmt.Errorf("fix permission for %s: %w", path, err)
-        }
-        diag.Warnf("Fixed permission for %s: %o → 0600", path, mode)
-    }
+// cmd/ende/prompt.go
+func readPromptSecret(in io.Reader, errw io.Writer) ([]byte, error) {
+    // 1. Detect whether stdin is a TTY
+    // 2. If TTY, use term.ReadPassword for masked input
+    // 3. If not TTY, fall back to current buffered reader behavior
+    // 4. Normalize trailing newline and reject empty input
+}
+```
+
+### 2. Add `ende doctor`
+**Current**: Safe setup checks are distributed across runtime failures.
+**Improvement**: Add one preflight command that validates local trust and file state before the user encrypts/decrypts.
+
+```go
+// cmd/ende/doctor_cmd.go
+type CheckResult struct {
+    Name    string
+    Status  string // ok, warn, fail
+    Message string
+}
+
+func runDoctor() []CheckResult {
+    // 1. Load keyring
+    // 2. Validate keyring path + file mode
+    // 3. Validate private key paths + permissions
+    // 4. Validate default signer exists
+    // 5. Validate recipient/sender pair consistency
     return nil
 }
 ```
 
-### 2. Add Timestamp Verification
-**Implementation**:
+### 3. Add Recipient Confirmation Before Encryption
+**Current**: Encryption resolves aliases immediately with no review step.
+**Improvement**: Add a human-readable summary before encryption, especially for first-send and multi-recipient flows.
+
 ```go
-// internal/crypto/envelope.go
-const DefaultMaxAge = 7 * 24 * time.Hour // 7 days
-
-func Open(envelopeBytes []byte, identities []age.Identity, verifyRequired bool, maxAge time.Duration) (*Envelope, []byte, error) {
-    // ... existing code ...
-    
-    // Timestamp verification
-    if maxAge > 0 {
-        createdAt, err := time.Parse(time.RFC3339, env.Metadata.CreatedAt)
-        if err != nil {
-            return nil, nil, fmt.Errorf("parse timestamp: %w", err)
-        }
-        if time.Since(createdAt) > maxAge {
-            return nil, nil, fmt.Errorf("envelope too old: created %s (max age: %s)", 
-                createdAt.Format(time.RFC3339), maxAge)
-        }
-    }
-    
-    // ... existing code ...
-}
-```
-
-### 3. Basic Audit Logging
-**Implementation**:
-```go
-// internal/audit/audit.go
-package audit
-
-import (
-    "encoding/json"
-    "os"
-    "path/filepath"
-    "time"
-)
-
-type Event struct {
-    Timestamp   time.Time `json:"timestamp"`
-    Operation   string    `json:"operation"` // encrypt, decrypt, verify
-    SenderID    string    `json:"sender_id,omitempty"`
-    Recipients  []string  `json:"recipients,omitempty"`
-    Success     bool      `json:"success"`
-    Error       string    `json:"error,omitempty"`
+// cmd/ende/crypto_cmd.go
+type EncryptSummary struct {
+    SignerID   string
+    Recipients []string
+    Out        string
+    TextOut    bool
 }
 
-func Log(event Event) error {
-    configDir, _, _, err := keyring.DefaultPaths()
-    if err != nil {
-        return err
-    }
-    
-    logPath := filepath.Join(configDir, "audit.log")
-    f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
-    if err != nil {
-        return err
-    }
-    defer f.Close()
-    
-    event.Timestamp = time.Now().UTC()
-    line, _ := json.Marshal(event)
-    f.Write(append(line, '\n'))
+func confirmEncrypt(summary EncryptSummary) error {
+    // Print alias + short fingerprint + output mode
+    // Require explicit confirmation unless --yes
     return nil
 }
 ```
 
-### 4. Shell Autocompletion Generation
-**Implementation**: Use Cobra's built-in functionality
-```go
-// cmd/ende/main.go
-func newCompletionCommand() *cobra.Command {
-    return &cobra.Command{
-        Use:   "completion [bash|zsh|fish|powershell]",
-        Short: "Generate shell completion script",
-        Long: `Generate shell completion script for ende.
+### 4. Safer Plaintext File Output
+**Current**: stdout is protected, but file outputs rely on the caller to choose safe paths and overwrite behavior.
+**Improvement**: Harden plaintext file writes without breaking automation.
 
-Example:
-  # Bash
-  source <(ende completion bash)
-  
-  # Zsh
-  ende completion zsh > ~/.zsh/completions/_ende
-  
-  # Fish
-  ende completion fish > ~/.config/fish/completions/ende.fish
-`,
-        ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
-        Args:      cobra.ExactArgs(1),
-        RunE: func(cmd *cobra.Command, args []string) error {
-            switch args[0] {
-            case "bash":
-                return cmd.Root().GenBashCompletion(os.Stdout)
-            case "zsh":
-                return cmd.Root().GenZshCompletion(os.Stdout)
-            case "fish":
-                return cmd.Root().GenFishCompletion(os.Stdout, true)
-            case "powershell":
-                return cmd.Root().GenPowerShellCompletion(os.Stdout)
-            }
-            return nil
-        },
-    }
+```go
+// internal/io/io.go
+type WriteOptions struct {
+    NoClobber bool
+    Mode      os.FileMode
+}
+
+func WritePlaintextFile(path string, data []byte, opts WriteOptions) error {
+    // Force 0600 for plaintext output
+    // Refuse overwrite when NoClobber is true
+    return nil
 }
 ```
 
@@ -164,7 +109,14 @@ Example:
 
 ## Phase 1: Core Security Enhancement (1-2 months)
 
-### 1.1 Key Backup Implementation
+### 1.1 Operator Safety Milestone
+1. Mask interactive prompt input
+2. Add `ende doctor`
+3. Add recipient confirmation and send summary
+4. Add safer plaintext file output defaults
+
+### 1.2 Key Backup Implementation
+
 **File Structure**:
 ```
 internal/backup/
@@ -213,7 +165,7 @@ func RestoreBackup(backupPath, password string) error {
 }
 ```
 
-### 1.2 Key Rotation Implementation
+### 1.3 Key Rotation Implementation
 **File Structure**:
 ```
 internal/rotation/

--- a/.kiro/security-architecture-analysis.md
+++ b/.kiro/security-architecture-analysis.md
@@ -85,7 +85,64 @@ internal/
 
 ## 3. Security Vulnerabilities and Improvements
 
-### 3.1 🟡 MEDIUM (downgraded): Key Rotation Mechanism
+### 3.1 🔴 HIGH: Interactive Secret Prompt Echo Risk
+
+**Issue:**
+```go
+// cmd/ende/prompt.go
+func readPromptSecret(in io.Reader, errw io.Writer) ([]byte, error) {
+    r := bufio.NewReader(in)
+    fmt.Fprint(errw, "secret> ")
+    v, err := r.ReadString('\n')
+    // plain terminal input, no masking
+}
+```
+
+**Impact:**
+- Secret may be visible on screen during entry
+- Secret can be captured in terminal recording / screen sharing sessions
+- Interactive flow gives users a false sense of "safe prompt" handling
+
+**Recommendations:**
+1. Use TTY-aware masked input for interactive secret entry
+2. Add optional confirmation prompt for high-risk flows
+3. Reject empty values and normalize trailing newline behavior
+4. Add tests for TTY and non-TTY prompt behavior
+
+### 3.2 🟡 MEDIUM: Missing Preflight Safety Diagnostics
+
+**Issue:**
+- No single command validates whether the local environment is ready for secure usage
+- Common setup mistakes are discovered only after an encrypt/decrypt failure
+
+**Impact:**
+- Users may operate with broken trust state
+- Misconfigured defaults increase onboarding friction
+- Security-sensitive warnings remain scattered across commands
+
+**Recommendations:**
+```bash
+ende doctor
+# Check signer defaults, key paths, key permissions,
+# recipient/sender consistency, and trust freshness warnings
+```
+
+### 3.3 🟡 MEDIUM: Recipient Mis-Selection Risk During Encryption
+
+**Issue:**
+- `encrypt` resolves aliases immediately without a human-readable confirmation step
+- Multi-recipient flows increase the chance of accidental over-sharing
+
+**Impact:**
+- Secret can be encrypted to the wrong recipient alias
+- Users may overlook who will be able to decrypt
+
+**Recommendations:**
+1. Add `--confirm` summary before encryption
+2. Show recipient alias, short fingerprint, signer, output path, and output mode
+3. Default to confirmation in first-send or multi-recipient scenarios
+
+### 3.4 🟡 MEDIUM (downgraded): Key Rotation Mechanism
 
 **Status:** `recipient rotate` and `sender rotate` commands are now implemented. They update the public key and fingerprint in the local keyring.
 
@@ -103,7 +160,7 @@ internal/
 4. Rotation audit trail
 ```
 
-### 3.2 🔴 HIGH: Missing Key Backup and Recovery Mechanism
+### 3.5 🔴 HIGH: Missing Key Backup and Recovery Mechanism
 
 **Issue:**
 - Keys are unrecoverable if lost
@@ -120,7 +177,7 @@ ende key restore --input encrypted-backup.age --passphrase
 ende key backup --threshold 2 --shares 3
 ```
 
-### 3.3 🟡 MEDIUM: GitHub SSH Key TOFU Verification Vulnerability
+### 3.6 🟡 MEDIUM: GitHub SSH Key TOFU Verification Vulnerability
 
 **Issue:**
 ```go
@@ -138,7 +195,7 @@ ende key backup --threshold 2 --shares 3
 2. Verify GitHub SSH key fingerprints through alternate channels
 3. Strengthen warning messages during key registration
 
-### 3.4 🟡 MEDIUM: Unencrypted Keyring File
+### 3.7 🟡 MEDIUM: Unencrypted Keyring File
 
 **Issue:**
 ```yaml
@@ -162,7 +219,7 @@ recipients:
 3. At minimum, encrypt sensitive fields only
 ```
 
-### 3.5 🟡 MEDIUM: Missing Timestamp Verification
+### 3.8 🟡 MEDIUM: Missing Timestamp Verification
 
 **Issue:**
 ```go
@@ -191,7 +248,7 @@ type Metadata struct {
 }
 ```
 
-### 3.6 🟡 MEDIUM: Missing Memory Security
+### 3.9 🟡 MEDIUM: Missing Memory Security
 
 **Issue:**
 ```go
@@ -218,7 +275,7 @@ func secureClear(b []byte) {
 // Or use mlock to prevent swapping
 ```
 
-### 3.7 🟢 LOW: Missing Logging and Audit Functionality
+### 3.10 🟢 LOW: Missing Logging and Audit Functionality
 
 **Issue:**
 - No logs for encrypt/decrypt operations
@@ -239,7 +296,7 @@ type AuditLog struct {
 // ~/.config/ende/audit.log (append-only)
 ```
 
-### 3.8 🟢 LOW: Missing Key Expiration Policy
+### 3.11 🟢 LOW: Missing Key Expiration Policy
 
 **Issue:**
 - Cannot set expiration date during key generation


### PR DESCRIPTION
Closes #9

## Summary
- update the Kiro roadmap documents to prioritize operator safety work
- move masked prompt, doctor, recipient confirmation, and plaintext hardening ahead of broader feature expansion
- align the security analysis and implementation plan with the new milestone ordering