### PR TITLE
feat: mask prompt input for interactive encrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ echo 'TOKEN=abc123' | ./ende encrypt -t bob --text -o secret.txt
 echo 'TOKEN=abc123' | ./ende encrypt -t bob --binary -o secret.ende
 ```
 
+4-3. Prompt for a secret interactively without echoing it to the terminal:
+```bash
+./ende encrypt -t bob --prompt -o secret.txt
+```
+Interactive prompt notes:
+- TTY input is masked so the secret is not echoed while typing.
+- Empty prompt input is rejected.
+- Non-interactive stdin/file workflows continue to work as before.
+
 5. Verify and decrypt:
 ```bash
 ./ende verify -i secret.ende

--- a/cmd/ende/prompt.go
+++ b/cmd/ende/prompt.go
@@ -5,7 +5,17 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"golang.org/x/term"
 )
+
+var isTerminal = term.IsTerminal
+var readPassword = term.ReadPassword
+
+type fdReader interface {
+	io.Reader
+	Fd() uintptr
+}
 
 func promptRecipientInput(in io.Reader, errw io.Writer) (alias string, keyOrShare string, err error) {
 	r := bufio.NewReader(in)
@@ -23,13 +33,31 @@ func promptRecipientInput(in io.Reader, errw io.Writer) (alias string, keyOrShar
 }
 
 func readPromptSecret(in io.Reader, errw io.Writer) ([]byte, error) {
-	r := bufio.NewReader(in)
 	fmt.Fprint(errw, "secret> ")
+
+	if tty, ok := in.(fdReader); ok && isTerminal(int(tty.Fd())) {
+		v, err := readPassword(int(tty.Fd()))
+		fmt.Fprintln(errw)
+		if err != nil {
+			return nil, fmt.Errorf("read prompt value: %w", err)
+		}
+		secret := strings.TrimRight(string(v), "\r\n")
+		if secret == "" {
+			return nil, fmt.Errorf("secret is required")
+		}
+		return []byte(secret), nil
+	}
+
+	r := bufio.NewReader(in)
 	v, err := r.ReadString('\n')
 	if err != nil && err != io.EOF {
 		return nil, fmt.Errorf("read prompt value: %w", err)
 	}
-	return []byte(strings.TrimRight(v, "\r\n")), nil
+	secret := strings.TrimRight(v, "\r\n")
+	if secret == "" {
+		return nil, fmt.Errorf("secret is required")
+	}
+	return []byte(secret), nil
 }
 
 func promptRegisterInput(in io.Reader, errw io.Writer) (alias string, recipientOrShare string, signingPublic string, err error) {

--- a/cmd/ende/prompt_test.go
+++ b/cmd/ende/prompt_test.go
@@ -130,3 +130,30 @@ func TestReadPromptSecret_TTYUsesMaskedInput(t *testing.T) {
 		t.Error("expected prompt message on stderr")
 	}
 }
+
+func TestReadPromptSecret_TTYRejectsEmptyInput(t *testing.T) {
+	oldIsTerminal := isTerminal
+	oldReadPassword := readPassword
+	t.Cleanup(func() {
+		isTerminal = oldIsTerminal
+		readPassword = oldReadPassword
+	})
+
+	isTerminal = func(fd int) bool {
+		return fd == 42
+	}
+	readPassword = func(fd int) ([]byte, error) {
+		return []byte(""), nil
+	}
+
+	var errBuf bytes.Buffer
+	in := fakeTTYReader{Reader: strings.NewReader("ignored\n"), fd: 42}
+
+	_, err := readPromptSecret(in, &errBuf)
+	if err == nil {
+		t.Fatal("expected error for empty TTY input")
+	}
+	if !strings.Contains(err.Error(), "secret is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cmd/ende/prompt_test.go
+++ b/cmd/ende/prompt_test.go
@@ -2,9 +2,19 @@ package main
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"testing"
 )
+
+type fakeTTYReader struct {
+	io.Reader
+	fd uintptr
+}
+
+func (f fakeTTYReader) Fd() uintptr {
+	return f.fd
+}
 
 func TestReadEnvelopeInteractive(t *testing.T) {
 	envelope := strings.Join([]string{
@@ -58,5 +68,65 @@ func TestReadEnvelopeInteractive_EmptyInput(t *testing.T) {
 	_, err := readEnvelopeInteractive(in, &errBuf)
 	if err == nil {
 		t.Fatal("expected error for empty input")
+	}
+}
+
+func TestReadPromptSecret_PipedInput(t *testing.T) {
+	var errBuf bytes.Buffer
+
+	got, err := readPromptSecret(strings.NewReader("super-secret\n"), &errBuf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != "super-secret" {
+		t.Fatalf("got %q, want %q", string(got), "super-secret")
+	}
+	if !strings.Contains(errBuf.String(), "secret> ") {
+		t.Error("expected prompt message on stderr")
+	}
+}
+
+func TestReadPromptSecret_RejectsEmptyInput(t *testing.T) {
+	var errBuf bytes.Buffer
+
+	_, err := readPromptSecret(strings.NewReader("\n"), &errBuf)
+	if err == nil {
+		t.Fatal("expected error for empty input")
+	}
+	if !strings.Contains(err.Error(), "secret is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestReadPromptSecret_TTYUsesMaskedInput(t *testing.T) {
+	oldIsTerminal := isTerminal
+	oldReadPassword := readPassword
+	t.Cleanup(func() {
+		isTerminal = oldIsTerminal
+		readPassword = oldReadPassword
+	})
+
+	isTerminal = func(fd int) bool {
+		return fd == 42
+	}
+	readPassword = func(fd int) ([]byte, error) {
+		if fd != 42 {
+			t.Fatalf("readPassword fd = %d, want 42", fd)
+		}
+		return []byte("masked-secret"), nil
+	}
+
+	var errBuf bytes.Buffer
+	in := fakeTTYReader{Reader: strings.NewReader("ignored\n"), fd: 42}
+
+	got, err := readPromptSecret(in, &errBuf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != "masked-secret" {
+		t.Fatalf("got %q, want %q", string(got), "masked-secret")
+	}
+	if !strings.Contains(errBuf.String(), "secret> ") {
+		t.Error("expected prompt message on stderr")
 	}
 }


### PR DESCRIPTION
Closes #10

## Summary
- mask `encrypt --prompt` input when stdin is a TTY
- keep piped stdin behavior unchanged for non-interactive usage
- reject empty prompt values and add focused tests for prompt behavior