### PR TITLE
feat: add doctor command for local checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,32 +114,42 @@ You can re-print a share token later:
 # alias override (optional, Enter to use token id):
 ```
 
+4. Run a local safety check before first real use:
+```bash
+./ende doctor
+```
+`ende doctor` checks:
+- keyring file presence and permissions
+- default signer configuration
+- private key file paths and `0600` permissions
+- recipient/trusted-sender registration consistency
+
 To remove a registered alias later:
 ```bash
 ./ende unregister alice
 ```
 
-4. Encrypt + sign (default: text to stdout):
+5. Encrypt + sign (default: text to stdout):
 ```bash
 echo 'TOKEN=abc123' | ./ende encrypt -t bob
 ```
 
-4-0. Encrypt from file input:
+5-0. Encrypt from file input:
 ```bash
 ./ende encrypt -t bob -f secrets.env -o secret.txt
 ```
 
-4-1. Save text output to file (optional):
+5-1. Save text output to file (optional):
 ```bash
 echo 'TOKEN=abc123' | ./ende encrypt -t bob --text -o secret.txt
 ```
 
-4-2. Raw binary output (optional):
+5-2. Raw binary output (optional):
 ```bash
 echo 'TOKEN=abc123' | ./ende encrypt -t bob --binary -o secret.ende
 ```
 
-5. Verify and decrypt:
+6. Verify and decrypt:
 ```bash
 ./ende verify -i secret.ende
 ./ende decrypt -i secret.ende -o decrypted.txt
@@ -151,6 +161,16 @@ Text envelope input is also supported:
 ./ende decrypt -i secret.txt -o decrypted.txt
 ./ende decrypt -i secret.txt --text-out
 ```
+
+## Health Checks
+
+Use `ende doctor` to validate local trust and configuration before troubleshooting a failed encrypt/decrypt flow:
+
+```bash
+./ende doctor
+```
+
+The command prints `ok`, `warn`, and `fail` results and exits non-zero when a hard failure is detected.
 
 ## Shortcuts
 - `ende enc` = `ende encrypt`

--- a/cmd/ende/doctor_cmd.go
+++ b/cmd/ende/doctor_cmd.go
@@ -70,8 +70,16 @@ func runDoctorChecks() ([]doctorCheck, error) {
 		checks = append(checks,
 			checkPrivatePath(fmt.Sprintf("key[%s].age_identity", id), keyEntry.AgeIdentity),
 			checkPrivatePath(fmt.Sprintf("key[%s].sign_private", id), keyEntry.SignPrivate),
-		)
-	}
+	for _, id := range store.AllKeyIDs() {
+		keyEntry, ok := store.Key(id)
+		if !ok {
+			checks = append(checks, doctorCheck{
+				Name:    fmt.Sprintf("key[%s]", id),
+				Status:  doctorStatusFail,
+				Message: fmt.Sprintf("key %q is listed but not found in store", id),
+			})
+			continue
+		}
 		checks = append(checks,
 			checkPrivatePath(fmt.Sprintf("key[%s].age_identity", id), keyEntry.AgeIdentity),
 			checkPrivatePath(fmt.Sprintf("key[%s].sign_private", id), keyEntry.SignPrivate),

--- a/cmd/ende/doctor_cmd.go
+++ b/cmd/ende/doctor_cmd.go
@@ -57,7 +57,21 @@ func runDoctorChecks() ([]doctorCheck, error) {
 	checks := []doctorCheck{checkKeyringFile(ringPath), checkDefaultSigner(store)}
 
 	for _, id := range store.AllKeyIDs() {
-		keyEntry, _ := store.Key(id)
+	for _, id := range store.AllKeyIDs() {
+		keyEntry, ok := store.Key(id)
+		if !ok {
+			checks = append(checks, doctorCheck{
+				Name:    fmt.Sprintf("key[%s]", id),
+				Status:  doctorStatusFail,
+				Message: fmt.Sprintf("key %q is listed but not found in store", id),
+			})
+			continue
+		}
+		checks = append(checks,
+			checkPrivatePath(fmt.Sprintf("key[%s].age_identity", id), keyEntry.AgeIdentity),
+			checkPrivatePath(fmt.Sprintf("key[%s].sign_private", id), keyEntry.SignPrivate),
+		)
+	}
 		checks = append(checks,
 			checkPrivatePath(fmt.Sprintf("key[%s].age_identity", id), keyEntry.AgeIdentity),
 			checkPrivatePath(fmt.Sprintf("key[%s].sign_private", id), keyEntry.SignPrivate),

--- a/cmd/ende/doctor_cmd.go
+++ b/cmd/ende/doctor_cmd.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/kuma/ende/internal/keyring"
+	"github.com/spf13/cobra"
+)
+
+type doctorStatus string
+
+const (
+	doctorStatusOK   doctorStatus = "ok"
+	doctorStatusWarn doctorStatus = "warn"
+	doctorStatusFail doctorStatus = "fail"
+)
+
+type doctorCheck struct {
+	Name    string
+	Status  doctorStatus
+	Message string
+}
+
+func newDoctorCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "doctor",
+		Short: "Run local trust and configuration health checks",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			checks, err := runDoctorChecks()
+			if err != nil {
+				return err
+			}
+			printDoctorReport(cmd.OutOrStdout(), checks)
+
+			failures := countDoctorChecks(checks, doctorStatusFail)
+			if failures > 0 {
+				return fmt.Errorf("doctor found %d failing check(s)", failures)
+			}
+			return nil
+		},
+	}
+}
+
+func runDoctorChecks() ([]doctorCheck, error) {
+	store, err := keyring.Load()
+	if err != nil {
+		return nil, err
+	}
+	_, ringPath, _, err := keyring.DefaultPaths()
+	if err != nil {
+		return nil, err
+	}
+
+	checks := []doctorCheck{checkKeyringFile(ringPath), checkDefaultSigner(store)}
+
+	for _, id := range store.AllKeyIDs() {
+		keyEntry, _ := store.Key(id)
+		checks = append(checks,
+			checkPrivatePath(fmt.Sprintf("key[%s].age_identity", id), keyEntry.AgeIdentity),
+			checkPrivatePath(fmt.Sprintf("key[%s].sign_private", id), keyEntry.SignPrivate),
+		)
+	}
+
+	checks = append(checks, checkRegisteredAliases(store)...)
+	return checks, nil
+}
+
+func checkKeyringFile(path string) doctorCheck {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return doctorCheck{
+				Name:    "keyring_file",
+				Status:  doctorStatusWarn,
+				Message: fmt.Sprintf("%s does not exist yet", path),
+			}
+		}
+		return doctorCheck{
+			Name:    "keyring_file",
+			Status:  doctorStatusFail,
+			Message: fmt.Sprintf("stat failed for %s: %v", path, err),
+		}
+	}
+	mode := info.Mode().Perm()
+	if mode != 0o600 {
+		return doctorCheck{
+			Name:    "keyring_file",
+			Status:  doctorStatusWarn,
+			Message: fmt.Sprintf("%s should have 0600 permissions, got %o", path, mode),
+		}
+	}
+	return doctorCheck{
+		Name:    "keyring_file",
+		Status:  doctorStatusOK,
+		Message: fmt.Sprintf("%s permissions are %o", path, mode),
+	}
+}
+
+func checkDefaultSigner(store *keyring.Store) doctorCheck {
+	defaultSigner := store.DefaultSigner()
+	if defaultSigner == "" {
+		if len(store.AllKeyIDs()) == 0 {
+			return doctorCheck{
+				Name:    "default_signer",
+				Status:  doctorStatusWarn,
+				Message: "no local keys found; generate a key before encrypting",
+			}
+		}
+		return doctorCheck{
+			Name:    "default_signer",
+			Status:  doctorStatusWarn,
+			Message: "no default signer configured; use `ende key use --name <id>` or pass --sign-as",
+		}
+	}
+	if _, ok := store.Key(defaultSigner); !ok {
+		return doctorCheck{
+			Name:    "default_signer",
+			Status:  doctorStatusFail,
+			Message: fmt.Sprintf("default signer %q is configured but missing from the local key store", defaultSigner),
+		}
+	}
+	return doctorCheck{
+		Name:    "default_signer",
+		Status:  doctorStatusOK,
+		Message: fmt.Sprintf("default signer is %s", defaultSigner),
+	}
+}
+
+func checkPrivatePath(name, path string) doctorCheck {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return doctorCheck{
+			Name:    name,
+			Status:  doctorStatusFail,
+			Message: "path is empty",
+		}
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return doctorCheck{
+			Name:    name,
+			Status:  doctorStatusFail,
+			Message: fmt.Sprintf("stat failed for %s: %v", path, err),
+		}
+	}
+	mode := info.Mode().Perm()
+	if mode != 0o600 {
+		return doctorCheck{
+			Name:    name,
+			Status:  doctorStatusFail,
+			Message: fmt.Sprintf("%s should have 0600 permissions, got %o", path, mode),
+		}
+	}
+	return doctorCheck{
+		Name:    name,
+		Status:  doctorStatusOK,
+		Message: fmt.Sprintf("%s permissions are %o", path, mode),
+	}
+}
+
+func checkRegisteredAliases(store *keyring.Store) []doctorCheck {
+	var checks []doctorCheck
+	for _, alias := range store.AllRecipientAliases() {
+		if _, ok := store.Sender(alias); ok {
+			checks = append(checks, doctorCheck{
+				Name:    fmt.Sprintf("alias[%s]", alias),
+				Status:  doctorStatusOK,
+				Message: "recipient and trusted sender are both registered",
+			})
+			continue
+		}
+		checks = append(checks, doctorCheck{
+			Name:    fmt.Sprintf("alias[%s]", alias),
+			Status:  doctorStatusWarn,
+			Message: "recipient exists without a matching trusted sender entry",
+		})
+	}
+	return checks
+}
+
+func printDoctorReport(w io.Writer, checks []doctorCheck) {
+	for _, check := range checks {
+		fmt.Fprintf(w, "[%s] %s: %s\n", check.Status, check.Name, check.Message)
+	}
+	fmt.Fprintf(w,
+		"summary: ok=%d warn=%d fail=%d\n",
+		countDoctorChecks(checks, doctorStatusOK),
+		countDoctorChecks(checks, doctorStatusWarn),
+		countDoctorChecks(checks, doctorStatusFail),
+	)
+}
+
+func countDoctorChecks(checks []doctorCheck, status doctorStatus) int {
+	count := 0
+	for _, check := range checks {
+		if check.Status == status {
+			count++
+		}
+	}
+	return count
+}

--- a/cmd/ende/doctor_cmd_test.go
+++ b/cmd/ende/doctor_cmd_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kuma/ende/internal/keyring"
+)
+
+func TestDoctorCommandHealthyConfig(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ENDE_CONFIG_DIR", configDir)
+
+	agePath := filepath.Join(configDir, "alice.agekey")
+	signPath := filepath.Join(configDir, "alice.signkey")
+	writeDoctorTestFile(t, agePath, "age-secret\n", 0o600)
+	writeDoctorTestFile(t, signPath, "sign-secret\n", 0o600)
+
+	store, err := keyring.Load()
+	if err != nil {
+		t.Fatalf("load keyring: %v", err)
+	}
+	store.AddKey(keyring.KeyEntry{
+		ID:          "alice",
+		AgeIdentity: agePath,
+		SignPrivate: signPath,
+		SignPublic:  "alice-public",
+	})
+	if err := store.AddSender("alice", "alice-public", "local-key", "", true); err != nil {
+		t.Fatalf("add sender: %v", err)
+	}
+	if err := store.SetDefaultSigner("alice"); err != nil {
+		t.Fatalf("set default signer: %v", err)
+	}
+	if err := store.Save(); err != nil {
+		t.Fatalf("save keyring: %v", err)
+	}
+
+	cmd := newDoctorCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("doctor command failed: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "[ok] default_signer: default signer is alice") {
+		t.Fatalf("expected default signer ok message, got:\n%s", got)
+	}
+	if !strings.Contains(got, "summary: ok=") {
+		t.Fatalf("expected summary output, got:\n%s", got)
+	}
+}
+
+func TestDoctorCommandReportsWarningsAndFailures(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ENDE_CONFIG_DIR", configDir)
+
+	agePath := filepath.Join(configDir, "bob.agekey")
+	signPath := filepath.Join(configDir, "bob.signkey")
+	writeDoctorTestFile(t, agePath, "age-secret\n", 0o600)
+	writeDoctorTestFile(t, signPath, "sign-secret\n", 0o644)
+
+	store, err := keyring.Load()
+	if err != nil {
+		t.Fatalf("load keyring: %v", err)
+	}
+	store.AddKey(keyring.KeyEntry{
+		ID:          "bob",
+		AgeIdentity: agePath,
+		SignPrivate: signPath,
+		SignPublic:  "bob-public",
+	})
+	if err := store.AddRecipient("bob", "age1bobrecipient", "register", "", false); err != nil {
+		t.Fatalf("add recipient: %v", err)
+	}
+	if err := store.Save(); err != nil {
+		t.Fatalf("save keyring: %v", err)
+	}
+
+	cmd := newDoctorCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("expected doctor command to fail")
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "[warn] default_signer: no default signer configured") {
+		t.Fatalf("expected default signer warning, got:\n%s", got)
+	}
+	if !strings.Contains(got, "[warn] alias[bob]: recipient exists without a matching trusted sender entry") {
+		t.Fatalf("expected alias warning, got:\n%s", got)
+	}
+	if !strings.Contains(got, "[fail] key[bob].sign_private:") {
+		t.Fatalf("expected private key failure, got:\n%s", got)
+	}
+}
+
+func writeDoctorTestFile(t *testing.T, path, contents string, mode os.FileMode) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), mode); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/cmd/ende/root.go
+++ b/cmd/ende/root.go
@@ -29,7 +29,7 @@ func main() {
 	root.SetVersionTemplate("{{.Use}} version {{.Version}}\ncommit: " + commit + "\nbuilt: " + date + "\n")
 	root.Flags().BoolP("version", "V", false, "print version information")
 	root.PersistentFlags().BoolVar(&debug, "debug", false, "enable diagnostic logs to stderr")
-	root.AddCommand(newVersionCommand(), newKeyCommand(), newRecipientCommand(), newSenderCommand(), newRegisterCommand(), newUnregisterCommand(), newEncryptCommand(), newDecryptCommand(), newVerifyCommand(), newTutorialCommand())
+	root.AddCommand(newVersionCommand(), newKeyCommand(), newRecipientCommand(), newSenderCommand(), newRegisterCommand(), newUnregisterCommand(), newEncryptCommand(), newDecryptCommand(), newVerifyCommand(), newTutorialCommand(), newDoctorCommand())
 
 	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
Closes #11

## Summary
- add a new `ende doctor` command for keyring, signer, file permission, and alias consistency checks
- print ok/warn/fail results with a summary and fail the command when hard failures are found
- cover healthy and broken configurations with command-level tests