### PR TITLE
feat: add encrypt confirmation summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,21 @@ echo 'TOKEN=abc123' | ./ende encrypt -t bob --text -o secret.txt
 echo 'TOKEN=abc123' | ./ende encrypt -t bob --binary -o secret.ende
 ```
 
+4-3. Review recipients and output details before encrypting:
+```bash
+echo 'TOKEN=abc123' | ./ende encrypt -t bob --confirm -o secret.txt
+```
+`--confirm` shows:
+- recipient alias and short fingerprint
+- signer key id
+- output target
+- output format
+
+For automation, you can keep the summary behavior in scripts and skip the prompt explicitly:
+```bash
+echo 'TOKEN=abc123' | ./ende encrypt -t bob --confirm --yes -o secret.txt
+```
+
 5. Verify and decrypt:
 ```bash
 ./ende verify -i secret.ende

--- a/cmd/ende/crypto_cmd.go
+++ b/cmd/ende/crypto_cmd.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bufio"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -13,7 +15,26 @@ import (
 	"github.com/kuma/ende/internal/keyring"
 	"github.com/kuma/ende/internal/policy"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
+
+type confirmFDReader interface {
+	io.Reader
+	Fd() uintptr
+}
+
+type encryptRecipientSummary struct {
+	Label       string
+	Fingerprint string
+	Source      string
+}
+
+type encryptSummary struct {
+	SignerID   string
+	Recipients []encryptRecipientSummary
+	OutputPath string
+	Format     string
+}
 
 func newEncryptCommand() *cobra.Command {
 	var tos []string
@@ -21,6 +42,8 @@ func newEncryptCommand() *cobra.Command {
 	var textOut bool
 	var binaryOut bool
 	var prompt bool
+	var confirm bool
+	var yes bool
 	cmd := &cobra.Command{
 		Use:   "encrypt",
 		Short: "Encrypt and sign secret payload",
@@ -71,13 +94,32 @@ func newEncryptCommand() *cobra.Command {
 
 			recipients := make([]age.Recipient, 0, len(tos))
 			hints := make([]string, 0, len(tos))
+			summaries := make([]encryptRecipientSummary, 0, len(tos))
 			for _, to := range tos {
-				r, hint, err := resolveRecipient(store, to)
+				r, hint, summary, err := resolveRecipient(store, to)
 				if err != nil {
 					return err
 				}
 				recipients = append(recipients, r)
 				hints = append(hints, hint)
+				summaries = append(summaries, summary)
+			}
+			if confirm && !yes {
+				confirmIn, closeConfirm, err := openConfirmationReader(cmd.InOrStdin())
+				if err != nil {
+					return err
+				}
+				if closeConfirm != nil {
+					defer closeConfirm.Close()
+				}
+				if err := confirmEncrypt(confirmIn, cmd.ErrOrStderr(), encryptSummary{
+					SignerID:   signAs,
+					Recipients: summaries,
+					OutputPath: out,
+					Format:     encryptOutputFormat(textOut, binaryOut),
+				}); err != nil {
+					return err
+				}
 			}
 			var plaintext []byte
 			if prompt {
@@ -116,6 +158,8 @@ func newEncryptCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&textOut, "text", true, "output ASCII-armored envelope for copy/paste transport (default true)")
 	cmd.Flags().BoolVar(&binaryOut, "binary", false, "output raw binary envelope")
 	cmd.Flags().BoolVar(&prompt, "prompt", false, "prompt for secret value interactively")
+	cmd.Flags().BoolVar(&confirm, "confirm", false, "show recipient summary and ask for confirmation before encrypting")
+	cmd.Flags().BoolVar(&yes, "yes", false, "skip confirmation prompt (useful with --confirm in automation)")
 	return cmd
 }
 
@@ -222,33 +266,88 @@ func newVerifyCommand() *cobra.Command {
 	return cmd
 }
 
-func resolveRecipient(store *keyring.Store, target string) (age.Recipient, string, error) {
+func resolveRecipient(store *keyring.Store, target string) (age.Recipient, string, encryptRecipientSummary, error) {
 	if strings.HasPrefix(target, "age1") {
 		r, err := age.ParseX25519Recipient(target)
 		if err != nil {
-			return nil, "", err
+			return nil, "", encryptRecipientSummary{}, err
 		}
-		return r, "direct:" + target, nil
+		return r, "direct:" + target, encryptRecipientSummary{
+			Label:       "direct",
+			Fingerprint: short(keyring.FingerprintAgePublicKey(target)),
+			Source:      "direct",
+		}, nil
 	}
 	if strings.HasPrefix(target, "github:") {
 		if r, ok := store.Recipient(target); ok {
 			rec, err := age.ParseX25519Recipient(r.AgePublic)
 			if err != nil {
-				return nil, "", err
+				return nil, "", encryptRecipientSummary{}, err
 			}
-			return rec, target, nil
+			return rec, target, encryptRecipientSummary{
+				Label:       target,
+				Fingerprint: short(r.Fingerprint),
+				Source:      r.Source,
+			}, nil
 		}
-		return nil, "", fmt.Errorf("github recipient %s not pinned in local keyring; run recipient add --github first", target)
+		return nil, "", encryptRecipientSummary{}, fmt.Errorf("github recipient %s not pinned in local keyring; run recipient add --github first", target)
 	}
 	r, ok := store.Recipient(target)
 	if !ok {
-		return nil, "", fmt.Errorf("recipient alias not found: %s", target)
+		return nil, "", encryptRecipientSummary{}, fmt.Errorf("recipient alias not found: %s", target)
 	}
 	rec, err := age.ParseX25519Recipient(r.AgePublic)
 	if err != nil {
-		return nil, "", fmt.Errorf("invalid recipient key for alias %s: %w", target, err)
+		return nil, "", encryptRecipientSummary{}, fmt.Errorf("invalid recipient key for alias %s: %w", target, err)
 	}
-	return rec, target, nil
+	return rec, target, encryptRecipientSummary{
+		Label:       target,
+		Fingerprint: short(r.Fingerprint),
+		Source:      r.Source,
+	}, nil
+}
+
+func openConfirmationReader(in io.Reader) (io.Reader, io.Closer, error) {
+	if tty, ok := in.(confirmFDReader); ok && term.IsTerminal(int(tty.Fd())) {
+		return in, nil, nil
+	}
+	f, err := os.Open("/dev/tty")
+	if err != nil {
+		return nil, nil, fmt.Errorf("confirmation requires a terminal; retry without --confirm or use --yes")
+	}
+	return f, f, nil
+}
+
+func confirmEncrypt(in io.Reader, errw io.Writer, summary encryptSummary) error {
+	fmt.Fprintln(errw, "Encrypt summary:")
+	for _, recipient := range summary.Recipients {
+		fmt.Fprintf(errw, "- recipient: %s (fp=%s source=%s)\n", recipient.Label, recipient.Fingerprint, recipient.Source)
+	}
+	fmt.Fprintf(errw, "- signer: %s\n", summary.SignerID)
+	fmt.Fprintf(errw, "- output: %s\n", summary.OutputPath)
+	fmt.Fprintf(errw, "- format: %s\n", summary.Format)
+	fmt.Fprint(errw, "Continue? [y/N]: ")
+
+	reader := bufio.NewReader(in)
+	answer, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return fmt.Errorf("read confirmation: %w", err)
+	}
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	if answer != "y" && answer != "yes" {
+		return fmt.Errorf("encryption cancelled")
+	}
+	return nil
+}
+
+func encryptOutputFormat(textOut, binaryOut bool) string {
+	if binaryOut {
+		return "binary"
+	}
+	if textOut {
+		return "armored text"
+	}
+	return "binary"
 }
 
 func loadIdentities(store *keyring.Store) ([]age.Identity, error) {

--- a/cmd/ende/crypto_cmd.go
+++ b/cmd/ende/crypto_cmd.go
@@ -1,13 +1,24 @@
 package main
 
 import (
+import (
 	"bufio"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"strings"
+
+	"filippo.io/age"
+	"github.com/kuma/ende/internal/crypto"
+	endeio "github.com/kuma/ende/internal/io"
+	"github.com/kuma/ende/internal/keyring"
+	"github.com/kuma/ende/internal/policy"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
 
 	"filippo.io/age"
 	"github.com/kuma/ende/internal/crypto"

--- a/cmd/ende/crypto_cmd.go
+++ b/cmd/ende/crypto_cmd.go
@@ -322,7 +322,11 @@ func openConfirmationReader(in io.Reader) (io.Reader, io.Closer, error) {
 	if tty, ok := in.(confirmFDReader); ok && term.IsTerminal(int(tty.Fd())) {
 		return in, nil, nil
 	}
-	f, err := os.Open("/dev/tty")
+	ttyPath := "/dev/tty"
+	if runtime.GOOS == "windows" {
+		ttyPath = "CON"
+	}
+	f, err := os.Open(ttyPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("confirmation requires a terminal; retry without --confirm or use --yes")
 	}

--- a/cmd/ende/crypto_cmd_test.go
+++ b/cmd/ende/crypto_cmd_test.go
@@ -1,6 +1,13 @@
 package main
 
-import "testing"
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"filippo.io/age"
+	"github.com/kuma/ende/internal/keyring"
+)
 
 func TestSha256Hex(t *testing.T) {
 	// Deterministic hash
@@ -38,5 +45,79 @@ func TestShort(t *testing.T) {
 			t.Errorf("short(%q) = %q, want %q",
 				tt.input, got, tt.want)
 		}
+	}
+}
+
+func TestResolveRecipientIncludesAliasSummary(t *testing.T) {
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("GenerateX25519Identity: %v", err)
+	}
+	recipient := identity.Recipient().String()
+	store := &keyring.Store{
+		Data: keyring.File{
+			Recipients: map[string]keyring.RecipientEntry{
+				"bob": {
+					Alias:       "bob",
+					AgePublic:   recipient,
+					Fingerprint: keyring.FingerprintAgePublicKey(recipient),
+					Source:      "register",
+				},
+			},
+		},
+	}
+
+	_, hint, summary, err := resolveRecipient(store, "bob")
+	if err != nil {
+		t.Fatalf("resolveRecipient: %v", err)
+	}
+	if hint != "bob" {
+		t.Fatalf("hint = %q, want %q", hint, "bob")
+	}
+	if summary.Label != "bob" {
+		t.Fatalf("summary label = %q, want %q", summary.Label, "bob")
+	}
+	if summary.Source != "register" {
+		t.Fatalf("summary source = %q, want %q", summary.Source, "register")
+	}
+	if summary.Fingerprint == "" {
+		t.Fatal("expected fingerprint summary")
+	}
+}
+
+func TestConfirmEncryptAcceptsYes(t *testing.T) {
+	var errBuf bytes.Buffer
+	err := confirmEncrypt(strings.NewReader("yes\n"), &errBuf, encryptSummary{
+		SignerID: "alice",
+		Recipients: []encryptRecipientSummary{
+			{Label: "bob", Fingerprint: "abc123", Source: "register"},
+		},
+		OutputPath: "secret.txt",
+		Format:     "armored text",
+	})
+	if err != nil {
+		t.Fatalf("confirmEncrypt: %v", err)
+	}
+	got := errBuf.String()
+	if !strings.Contains(got, "recipient: bob") {
+		t.Fatalf("expected recipient summary, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Continue? [y/N]: ") {
+		t.Fatalf("expected confirmation prompt, got:\n%s", got)
+	}
+}
+
+func TestConfirmEncryptRejectsNegativeAnswer(t *testing.T) {
+	var errBuf bytes.Buffer
+	err := confirmEncrypt(strings.NewReader("n\n"), &errBuf, encryptSummary{
+		SignerID:   "alice",
+		OutputPath: "-",
+		Format:     "armored text",
+	})
+	if err == nil {
+		t.Fatal("expected cancellation error")
+	}
+	if !strings.Contains(err.Error(), "cancelled") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
Closes #12

## Summary
- add `--confirm` and `--yes` options to `ende encrypt`
- show recipient fingerprints, signer, output target, and output format before sealing
- add tests for recipient summaries and confirmation acceptance/cancellation flows