### PR TITLE
feat: harden plaintext output handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,15 @@ Text envelope input is also supported:
 ./ende decrypt -i secret.txt --text-out
 ```
 
+Safer plaintext output options:
+```bash
+# Refuse to overwrite an existing plaintext file
+./ende decrypt -i secret.ende -o decrypted.txt --no-clobber
+
+# Write plaintext to a temporary 0600 file and print the path
+./ende decrypt -i secret.ende --out-temp
+```
+
 ## Shortcuts
 - `ende enc` = `ende encrypt`
 - `ende dec` = `ende decrypt`

--- a/cmd/ende/crypto_cmd.go
+++ b/cmd/ende/crypto_cmd.go
@@ -123,6 +123,8 @@ func newDecryptCommand() *cobra.Command {
 	var in, out string
 	var verifyRequired bool
 	var textOut bool
+	var noClobber bool
+	var outTemp bool
 	cmd := &cobra.Command{
 		Use:   "decrypt",
 		Short: "Verify and decrypt envelope",
@@ -130,8 +132,10 @@ func newDecryptCommand() *cobra.Command {
 			"dec",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := policy.EnsurePlaintextOutputAllowed(out); err != nil {
-				return err
+			if !outTemp {
+				if err := policy.EnsurePlaintextOutputAllowed(out); err != nil {
+					return err
+				}
 			}
 			store, err := keyring.Load()
 			if err != nil {
@@ -167,7 +171,15 @@ func newDecryptCommand() *cobra.Command {
 					return fmt.Errorf("trusted sender mismatch for %s", env.Metadata.SenderKeyID)
 				}
 			}
-			if err := endeio.WriteOutput(out, plaintext); err != nil {
+			if outTemp {
+				path, err := endeio.WriteTempOutput(plaintext)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "wrote plaintext to temporary file: %s\n", path)
+				return nil
+			}
+			if err := endeio.WriteOutputWithOptions(out, plaintext, endeio.WriteOptions{NoClobber: noClobber}); err != nil {
 				return err
 			}
 			return nil
@@ -178,7 +190,13 @@ func newDecryptCommand() *cobra.Command {
 			if out != "" && out != "-" {
 				return fmt.Errorf("--text-out cannot be used with file output")
 			}
+			if outTemp {
+				return fmt.Errorf("--text-out cannot be used with --out-temp")
+			}
 			out = "-"
+		}
+		if outTemp && out != "" {
+			return fmt.Errorf("--out-temp cannot be used with --out")
 		}
 		return nil
 	}
@@ -186,6 +204,8 @@ func newDecryptCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&out, "out", "o", "", "output plaintext path or - (explicit)")
 	cmd.Flags().BoolVar(&verifyRequired, "verify-required", true, "require signature verification")
 	cmd.Flags().BoolVar(&textOut, "text-out", false, "print decrypted plaintext to stdout")
+	cmd.Flags().BoolVar(&noClobber, "no-clobber", false, "refuse to overwrite an existing plaintext output file")
+	cmd.Flags().BoolVar(&outTemp, "out-temp", false, "write plaintext to a temporary 0600 file")
 	return cmd
 }
 

--- a/cmd/ende/crypto_cmd_test.go
+++ b/cmd/ende/crypto_cmd_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestSha256Hex(t *testing.T) {
 	// Deterministic hash
@@ -38,5 +41,35 @@ func TestShort(t *testing.T) {
 			t.Errorf("short(%q) = %q, want %q",
 				tt.input, got, tt.want)
 		}
+	}
+}
+
+func TestDecryptCommandRejectsOutTempWithOut(t *testing.T) {
+	cmd := newDecryptCommand()
+	cmd.SetArgs([]string{"--out-temp", "--out", "plain.txt"})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected command to fail")
+	}
+	if !strings.Contains(err.Error(), "--out-temp cannot be used with --out") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDecryptCommandRejectsOutTempWithTextOut(t *testing.T) {
+	cmd := newDecryptCommand()
+	cmd.SetArgs([]string{"--out-temp", "--text-out"})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected command to fail")
+	}
+	if !strings.Contains(err.Error(), "--text-out cannot be used with --out-temp") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -5,6 +5,10 @@ import (
 	"os"
 )
 
+type WriteOptions struct {
+	NoClobber bool
+}
+
 func ReadInput(path string) ([]byte, error) {
 	if path == "" || path == "-" {
 		return os.ReadFile("/dev/stdin")
@@ -17,9 +21,24 @@ func ReadInput(path string) ([]byte, error) {
 }
 
 func WriteOutput(path string, b []byte) error {
+	return WriteOutputWithOptions(path, b, WriteOptions{})
+}
+
+func WriteOutputWithOptions(path string, b []byte, opts WriteOptions) error {
 	if path == "" || path == "-" {
 		if _, err := os.Stdout.Write(b); err != nil {
 			return fmt.Errorf("write stdout: %w", err)
+		}
+		return nil
+	}
+	if opts.NoClobber {
+		f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err != nil {
+			return fmt.Errorf("write output file %s: %w", path, err)
+		}
+		defer f.Close()
+		if _, err := f.Write(b); err != nil {
+			return fmt.Errorf("write output file %s: %w", path, err)
 		}
 		return nil
 	}
@@ -27,4 +46,24 @@ func WriteOutput(path string, b []byte) error {
 		return fmt.Errorf("write output file %s: %w", path, err)
 	}
 	return nil
+}
+
+func WriteTempOutput(b []byte) (string, error) {
+	f, err := os.CreateTemp("", "ende-plaintext-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp output file: %w", err)
+	}
+	name := f.Name()
+	if err := f.Chmod(0o600); err != nil {
+		f.Close()
+		return "", fmt.Errorf("chmod temp output file %s: %w", name, err)
+	}
+	if _, err := f.Write(b); err != nil {
+		f.Close()
+		return "", fmt.Errorf("write temp output file %s: %w", name, err)
+	}
+	if err := f.Close(); err != nil {
+		return "", fmt.Errorf("close temp output file %s: %w", name, err)
+	}
+	return name, nil
 }

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -56,10 +56,12 @@ func WriteTempOutput(b []byte) (string, error) {
 	name := f.Name()
 	if err := f.Chmod(0o600); err != nil {
 		f.Close()
+		os.Remove(name)
 		return "", fmt.Errorf("chmod temp output file %s: %w", name, err)
 	}
 	if _, err := f.Write(b); err != nil {
 		f.Close()
+		os.Remove(name)
 		return "", fmt.Errorf("write temp output file %s: %w", name, err)
 	}
 	if err := f.Close(); err != nil {

--- a/internal/io/io_test.go
+++ b/internal/io/io_test.go
@@ -192,3 +192,43 @@ func TestWriteOutputEmptyContent(t *testing.T) {
 		t.Fatalf("expected empty file, got %d bytes", len(result))
 	}
 }
+
+func TestWriteOutputWithOptionsNoClobber(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "existing.txt")
+
+	if err := os.WriteFile(testFile, []byte("existing"), 0o600); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	err := WriteOutputWithOptions(testFile, []byte("new"), WriteOptions{NoClobber: true})
+	if err == nil {
+		t.Fatal("expected no-clobber write to fail")
+	}
+}
+
+func TestWriteTempOutput(t *testing.T) {
+	content := []byte("temp plaintext")
+
+	path, err := WriteTempOutput(content)
+	if err != nil {
+		t.Fatalf("WriteTempOutput failed: %v", err)
+	}
+	defer os.Remove(path)
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("content mismatch: got %q, want %q", got, content)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat failed: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("file permission mismatch: got %o, want 0600", mode)
+	}
+}


### PR DESCRIPTION
Closes #13

## Summary
- add no-clobber and temporary-file support for plaintext decrypt output
- keep plaintext file permissions locked to `0600` through dedicated output helpers
- add tests for temp output, overwrite protection, and decrypt flag conflicts