### PR TITLE
fix: restore merged files and add PR test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  go-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests
+        run: go test ./cmd/ende ./internal/...

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ echo 'TOKEN=abc123' | ./ende encrypt -t bob --text -o secret.txt
 echo 'TOKEN=abc123' | ./ende encrypt -t bob --binary -o secret.ende
 ```
 
-4-3. Prompt for a secret interactively without echoing it to the terminal:
+5-3. Prompt for a secret interactively without echoing it to the terminal:
 ```bash
 ./ende encrypt -t bob --prompt -o secret.txt
 ```
@@ -157,8 +157,8 @@ Interactive prompt notes:
 - TTY input is masked so the secret is not echoed while typing.
 - Empty prompt input is rejected.
 - Non-interactive stdin/file workflows continue to work as before.
-6. Verify and decrypt:
-4-3. Review recipients and output details before encrypting:
+
+5-4. Review recipients and output details before encrypting:
 ```bash
 echo 'TOKEN=abc123' | ./ende encrypt -t bob --confirm -o secret.txt
 ```
@@ -173,7 +173,7 @@ For automation, you can keep the summary behavior in scripts and skip the prompt
 echo 'TOKEN=abc123' | ./ende encrypt -t bob --confirm --yes -o secret.txt
 ```
 
-5. Verify and decrypt:
+6. Verify and decrypt:
 ```bash
 ./ende verify -i secret.ende
 ./ende decrypt -i secret.ende -o decrypted.txt
@@ -194,6 +194,8 @@ Safer plaintext output options:
 # Write plaintext to a temporary 0600 file and print the path
 ./ende decrypt -i secret.ende --out-temp
 ```
+
+`--out-temp` is useful when you want Ende to choose a short-lived secure file path for you.
 
 ## Health Checks
 

--- a/cmd/ende/crypto_cmd.go
+++ b/cmd/ende/crypto_cmd.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-import (
 	"bufio"
 	"crypto/sha256"
 	"encoding/hex"
@@ -10,15 +9,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-
-	"filippo.io/age"
-	"github.com/kuma/ende/internal/crypto"
-	endeio "github.com/kuma/ende/internal/io"
-	"github.com/kuma/ende/internal/keyring"
-	"github.com/kuma/ende/internal/policy"
-	"github.com/spf13/cobra"
-	"golang.org/x/term"
-)
 
 	"filippo.io/age"
 	"github.com/kuma/ende/internal/crypto"

--- a/cmd/ende/crypto_cmd_test.go
+++ b/cmd/ende/crypto_cmd_test.go
@@ -74,6 +74,10 @@ func TestDecryptCommandRejectsOutTempWithTextOut(t *testing.T) {
 		t.Fatal("expected command to fail")
 	}
 	if !strings.Contains(err.Error(), "--text-out cannot be used with --out-temp") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestResolveRecipientIncludesAliasSummary(t *testing.T) {
 	identity, err := age.GenerateX25519Identity()
 	if err != nil {

--- a/cmd/ende/doctor_cmd.go
+++ b/cmd/ende/doctor_cmd.go
@@ -57,20 +57,6 @@ func runDoctorChecks() ([]doctorCheck, error) {
 	checks := []doctorCheck{checkKeyringFile(ringPath), checkDefaultSigner(store)}
 
 	for _, id := range store.AllKeyIDs() {
-	for _, id := range store.AllKeyIDs() {
-		keyEntry, ok := store.Key(id)
-		if !ok {
-			checks = append(checks, doctorCheck{
-				Name:    fmt.Sprintf("key[%s]", id),
-				Status:  doctorStatusFail,
-				Message: fmt.Sprintf("key %q is listed but not found in store", id),
-			})
-			continue
-		}
-		checks = append(checks,
-			checkPrivatePath(fmt.Sprintf("key[%s].age_identity", id), keyEntry.AgeIdentity),
-			checkPrivatePath(fmt.Sprintf("key[%s].sign_private", id), keyEntry.SignPrivate),
-	for _, id := range store.AllKeyIDs() {
 		keyEntry, ok := store.Key(id)
 		if !ok {
 			checks = append(checks, doctorCheck{


### PR DESCRIPTION
## Summary
- fix merge damage in `crypto_cmd.go`, `doctor_cmd.go`, and `crypto_cmd_test.go`
- clean up the merged README quickstart flow for the new operator-safety features
- add a GitHub Actions test workflow so PRs automatically run `go test ./cmd/ende ./internal/...`

## Validation
- go test ./cmd/ende ./internal/...
- checked for conflict markers outside vendor code