### PR TITLE
build: automate releases and homebrew tap updates with goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
   workflow_dispatch:
 
 permissions:
@@ -14,39 +14,34 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
-      - name: Build release packages
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
         env:
-          VERSION: ${{ github.ref_name }}
-          COMMIT: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          SHORT_COMMIT="$(echo "$COMMIT" | cut -c1-7)"
-          make package VERSION="$VERSION" COMMIT="$SHORT_COMMIT"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
-      - name: Upload workflow artifact
+      - name: Upload workflow artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ende-release-${{ github.ref_name }}
           path: |
-            dist/ende*
-            dist/packages/*
+            dist/ende-*
+            dist/*.tar.gz
+            dist/*.zip
+            dist/SHA256SUMS
+            dist/homebrew/ende.rb
           if-no-files-found: error
-
-      - name: Create GitHub Release and upload assets
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          generate_release_notes: true
-          files: |
-            dist/ende*
-            dist/packages/*.tar.gz
-            dist/packages/*.zip
-            dist/packages/SHA256SUMS

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,69 @@
+version: 2
+
+project_name: ende
+
+before:
+  hooks:
+    - go test ./...
+
+builds:
+  - id: ende
+    main: ./cmd/ende
+    binary: ende
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.version={{ .Version }} -X main.commit={{ .ShortCommit }} -X main.date={{ .Date }}
+
+archives:
+  - id: binaries
+    ids:
+      - ende
+    formats:
+      - binary
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+
+  - id: packages
+    ids:
+      - ende
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+checksum:
+  name_template: "SHA256SUMS"
+
+release:
+  github:
+    owner: DevopsArtFactory
+    name: ende
+
+brews:
+  - ids:
+      - packages
+    name: ende
+    directory: "."
+    homepage: "https://github.com/DevopsArtFactory/ende"
+    description: "Secure CLI for DevOps teams to share secrets using public-key encryption and sender verification."
+    license: "MIT"
+    repository:
+      owner: DevopsArtFactory
+      name: homebrew-ende
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    commit_author:
+      name: github-actions[bot]
+      email: 41898282+github-actions[bot]@users.noreply.github.com
+    commit_msg_template: "Update Homebrew formula for {{ .ProjectName }} {{ .Tag }}"
+    download_strategy: CurlDownloadStrategy

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ brew tap DevopsArtFactory/ende https://github.com/DevopsArtFactory/homebrew-ende
 brew install ende
 ```
 
+The Homebrew tap formula is updated automatically from Git tags through GoReleaser.
+
 Upgrade:
 ```bash
 brew update
@@ -33,6 +35,14 @@ Verify:
 ```bash
 ende --version
 ```
+
+## Release Automation
+- Tagged releases use GoReleaser to build macOS, Linux, and Windows binaries.
+- GoReleaser publishes release archives and raw binaries to GitHub Releases.
+- GoReleaser updates the Homebrew tap repository at [DevopsArtFactory/homebrew-ende](https://github.com/DevopsArtFactory/homebrew-ende).
+
+Required GitHub Actions secret:
+- `HOMEBREW_TAP_GITHUB_TOKEN`: token with `contents: write` access to `DevopsArtFactory/homebrew-ende`
 
 ## Install from GitHub Release (Linux / Windows)
 Replace `vX.Y.Z` with the release tag.

--- a/USAGE_EN.md
+++ b/USAGE_EN.md
@@ -318,7 +318,8 @@ Options:
   - `verify-required=true` by default in `decrypt`
   - unknown sender IDs are rejected during decrypt
   - Plaintext stdout blocked by default (`--out -` required)
-  - Private key file permission `0600` enforced
+  - Private key file permission `0600` enforced on Unix-like systems
+  - Windows skips POSIX mode checks because NTFS ACLs do not map to `0600`
 
 - Operational safety
   - Secrets are handled via file/stdin paths, not CLI secret arguments

--- a/USAGE_KO.md
+++ b/USAGE_KO.md
@@ -318,7 +318,8 @@ recipient + trusted sender를 한 번에 등록
   - `decrypt`에서 `verify-required=true` 기본
   - unknown sender ID는 복호화 단계에서 거부
   - 평문 stdout 기본 차단 (`--out -` 명시 필요)
-  - 개인키 파일 권한 `0600` 강제
+  - Unix 계열에서는 개인키 파일 권한 `0600` 강제
+  - Windows는 NTFS ACL이 `0600`과 직접 매핑되지 않아 POSIX 모드 검사를 생략
 
 - 운영/감사 관점
   - 비밀값을 CLI 인자로 받지 않고 파일/stdin 중심 처리

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -3,12 +3,17 @@ package policy
 import (
 	"fmt"
 	"os"
+	"runtime"
 )
 
 func EnsurePrivateFile(path string) error {
 	info, err := os.Stat(path)
 	if err != nil {
 		return fmt.Errorf("stat private file %s: %w", path, err)
+	}
+	if runtime.GOOS == "windows" {
+		// Windows ACLs do not map cleanly to POSIX mode bits.
+		return nil
 	}
 	mode := info.Mode().Perm()
 	if mode != 0o600 {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -3,6 +3,7 @@ package policy
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -17,6 +18,12 @@ func TestEnsurePrivateFile(t *testing.T) {
 	}
 	if err := os.Chmod(p, 0o644); err != nil {
 		t.Fatal(err)
+	}
+	if runtime.GOOS == "windows" {
+		if err := EnsurePrivateFile(p); err != nil {
+			t.Fatalf("expected Windows permission check bypass: %v", err)
+		}
+		return
 	}
 	if err := EnsurePrivateFile(p); err == nil {
 		t.Fatal("expected failure for 0644")


### PR DESCRIPTION
## Summary
- switch the tag release workflow from manual Makefile packaging to GoReleaser
- publish release archives, raw binaries, and checksums from GitHub Actions
- auto-update the `DevopsArtFactory/homebrew-ende` tap repository on tagged releases
- document the required GitHub Actions secret for tap updates

## Testing
- `go test ./...`
- `goreleaser check`
- `goreleaser release --snapshot --clean --skip=publish`
