### PR TITLE
fix: handle private key permission checks correctly on windows

### DIFF
--- a/USAGE_EN.md
+++ b/USAGE_EN.md
@@ -318,7 +318,8 @@ Options:
   - `verify-required=true` by default in `decrypt`
   - unknown sender IDs are rejected during decrypt
   - Plaintext stdout blocked by default (`--out -` required)
-  - Private key file permission `0600` enforced
+  - Private key file permission `0600` enforced on Unix-like systems
+  - Windows skips POSIX mode checks because NTFS ACLs do not map to `0600`
 
 - Operational safety
   - Secrets are handled via file/stdin paths, not CLI secret arguments

--- a/USAGE_KO.md
+++ b/USAGE_KO.md
@@ -318,7 +318,8 @@ recipient + trusted sender를 한 번에 등록
   - `decrypt`에서 `verify-required=true` 기본
   - unknown sender ID는 복호화 단계에서 거부
   - 평문 stdout 기본 차단 (`--out -` 명시 필요)
-  - 개인키 파일 권한 `0600` 강제
+  - Unix 계열에서는 개인키 파일 권한 `0600` 강제
+  - Windows는 NTFS ACL이 `0600`과 직접 매핑되지 않아 POSIX 모드 검사를 생략
 
 - 운영/감사 관점
   - 비밀값을 CLI 인자로 받지 않고 파일/stdin 중심 처리

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -3,12 +3,17 @@ package policy
 import (
 	"fmt"
 	"os"
+	"runtime"
 )
 
 func EnsurePrivateFile(path string) error {
 	info, err := os.Stat(path)
 	if err != nil {
 		return fmt.Errorf("stat private file %s: %w", path, err)
+	}
+	if runtime.GOOS == "windows" {
+		// Windows ACLs do not map cleanly to POSIX mode bits.
+		return nil
 	}
 	mode := info.Mode().Perm()
 	if mode != 0o600 {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -3,6 +3,7 @@ package policy
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -17,6 +18,12 @@ func TestEnsurePrivateFile(t *testing.T) {
 	}
 	if err := os.Chmod(p, 0o644); err != nil {
 		t.Fatal(err)
+	}
+	if runtime.GOOS == "windows" {
+		if err := EnsurePrivateFile(p); err != nil {
+			t.Fatalf("expected Windows permission check bypass: %v", err)
+		}
+		return
 	}
 	if err := EnsurePrivateFile(p); err == nil {
 		t.Fatal("expected failure for 0644")


### PR DESCRIPTION
## Summary
- skip the POSIX `0600` private key permission check on Windows
- keep strict `0600` enforcement on Unix-like systems
- update tests and usage docs to reflect the OS-specific behavior

## Why
Windows uses NTFS ACLs instead of POSIX mode bits, so checking for `0600` causes false failures such as `must have 0600 permission, got 666`.

## Testing
- `go test ./...`
